### PR TITLE
Create Shipping Methods and Order Status tables with seed data

### DIFF
--- a/prisma/migrations/20240515210538_add_shipping_methods_table/migration.sql
+++ b/prisma/migrations/20240515210538_add_shipping_methods_table/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - Added the required column `option_id` to the `product_categories` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "product_categories" ADD COLUMN     "option_id" INTEGER NOT NULL;
+
+-- CreateTable
+CREATE TABLE "shipping_methods" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(25) NOT NULL,
+    "price" DECIMAL(10,2) NOT NULL,
+
+    CONSTRAINT "shipping_methods_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/migrations/20240515215316_add_order_status_table/migration.sql
+++ b/prisma/migrations/20240515215316_add_order_status_table/migration.sql
@@ -1,0 +1,7 @@
+-- CreateTable
+CREATE TABLE "order_status" (
+    "id" SERIAL NOT NULL,
+    "status" VARCHAR(50) NOT NULL,
+
+    CONSTRAINT "order_status_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,3 +90,18 @@ model ProductItemOptionValue {
   @@id([product_items_id, option_values_id])
   @@map("product_item_option_values")
 }
+
+model ShippingMethod {
+  id    Int     @id @default(autoincrement())
+  name  String  @db.VarChar(25)
+  price Decimal @db.Decimal(10, 2)
+
+  @@map("shipping_methods")
+}
+
+model OrderStatus {
+  id     Int    @id @default(autoincrement())
+  status String @db.VarChar(50)
+
+  @@map("order_status")
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -11,6 +11,8 @@ import { PrismaClient } from '@prisma/client';
 // import { seedClothingWomens } from './seedProducts/seedClothingWomens';
 // import { seedClothingWomens_2 } from './seedProducts/seedClothingWomens_2';
 import { seedUpdatePhoto } from './seedProducts/seedUpdatePhoto';
+import { seedShippingMethods } from './seedOrders/seedShippingMethods';
+import { seedOrderStatus } from './seedOrders/seedOrderStatus';
 
 const prisma = new PrismaClient();
 
@@ -27,6 +29,8 @@ async function main() {
   // await seedBabyCare();
   // await seedBabyClothing();
   await seedUpdatePhoto();
+  await seedShippingMethods();
+  await seedOrderStatus();
 }
 
 main()

--- a/prisma/seedOrders/seedOrderStatus.ts
+++ b/prisma/seedOrders/seedOrderStatus.ts
@@ -1,0 +1,32 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export async function seedOrderStatus() {
+  const orderStatus = [
+    'Processing',
+    'Ready for Pickup',
+    'Shipped',
+    'Delivered',
+    'Picked Up',
+  ];
+
+  for (const status of orderStatus) {
+    const existingStatus = await prisma.orderStatus.findFirst({
+      where: {
+        status: status,
+      },
+    });
+
+    if (!existingStatus) {
+      const newStatus = await prisma.orderStatus.create({
+        data: {
+          status,
+        },
+      });
+      console.log(`User Created: ${newStatus.status}`);
+    } else {
+      console.log(`User already exists: ${status}`);
+    }
+  }
+}

--- a/prisma/seedOrders/seedShippingMethods.ts
+++ b/prisma/seedOrders/seedShippingMethods.ts
@@ -1,0 +1,33 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export async function seedShippingMethods() {
+  const shippingMethods = [
+    {
+      name: 'Pick up',
+      price: 0.0,
+    },
+    {
+      name: 'Delivery',
+      price: 8.0,
+    },
+  ];
+
+  for (const method of shippingMethods) {
+    const existingMethod = await prisma.shippingMethod.findFirst({
+      where: {
+        name: method.name,
+      },
+    });
+
+    if (!existingMethod) {
+      const newMethod = await prisma.shippingMethod.create({
+        data: method,
+      });
+      console.log(`User Created: ${newMethod.name}`);
+    } else {
+      console.log(`User already exists: ${method.name}`);
+    }
+  }
+}


### PR DESCRIPTION
**Jira Ticket**<br>
Link: [https://derek-team-lva74agprdbm.atlassian.net/browse/SP-107?atlOrigin=eyJpIjoiY2QxYzA4OWRhYTBhNDgxZjk3ZDMzMTcyN2RjOTMyMTUiLCJwIjoiaiJ9](https://derek-team-lva74agprdbm.atlassian.net/browse/SP-107?atlOrigin=eyJpIjoiY2QxYzA4OWRhYTBhNDgxZjk3ZDMzMTcyN2RjOTMyMTUiLCJwIjoiaiJ9)

**Description**<br>
_Add a sensible description to this pull request:_
Create Shipping Methods and Order Status tables with seed data

- Added: `prisma/migrations/20240515210538_add_shipping_methods_table/migration.sql`, `prisma/migrations/20240515215316_add_order_status_table/migration.sql`, `prisma/seedOrders/seedOrderStatus.ts`, `prisma/seedOrders/seedShippingMethods.ts`
- Changed: `prisma/schema.prisma`, `prisma/seed.ts`
- Refactored:
- Removed:

**Screenshots** (optional)<br>
(_drag and drop images here_)
<img width="779" alt="Screenshot 2024-05-15 162408" src="https://github.com/Snow-Penguins/cacart-backend/assets/90408504/3d411e77-1898-47f4-9265-32ecec70b77c">


**Unit Test**<br>
_Describe any unit tests or their results (if applicable):_
